### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS=-I m4
+
 data_dbdir = $(sysconfdir)/sonic
 data_db_DATA = cfg/sai_vm_db.cfg \
 cfg/sai-db/create_sai_acl_table.sql        cfg/sai-db/drop_sai_acl_table.sql \

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([sai-vm],[1.0.1],[sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CHECK_HEADERS([libxml/parser.h])
 
 # Checks for programs.


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.